### PR TITLE
fix (MainActivity): Adds missing code for correct functionality in previous PR

### DIFF
--- a/app/src/main/java/br/com/jonatas/metronomeplus/presenter/ui/MainActivity.kt
+++ b/app/src/main/java/br/com/jonatas/metronomeplus/presenter/ui/MainActivity.kt
@@ -1,24 +1,16 @@
 package br.com.jonatas.metronomeplus.presenter.ui
 
-import android.content.res.AssetManager
-import android.media.AudioManager
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import br.com.jonatas.metronomeplus.databinding.ActivityMainBinding
-import br.com.jonatas.metronomeplus.domain.model.Beat
-import br.com.jonatas.metronomeplus.domain.model.BeatState
 
 class MainActivity : BaseActivity() {
 
     private val binding by lazy {
         ActivityMainBinding.inflate(layoutInflater)
     }
-    private var bpm: Int = 120
-    private var beats: Int = 4
-    private var tones: MutableList<Beat> = mutableListOf()
-    private var isPlaying = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -28,120 +20,6 @@ class MainActivity : BaseActivity() {
             val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
             v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
             insets
-        }
-
-        setTextHelloC()
-        setDefaultStreamValues()
-        native_onInit(assets)
-        setupMetronome()
-        setupConfigs()
-    }
-
-    override fun onDestroy() {
-        super.onDestroy()
-        native_onEnd()
-    }
-
-    private fun setupConfigs() {
-        native_SetBPM(bpm)
-        native_SetBeats(tones.map { it }.toTypedArray())
-    }
-
-    private fun setupMetronome() {
-        //TODO verificar a utilizar de coroutines aqui para poder atualizar a interface sem travamentos.
-        binding.btnPlayPause.setOnClickListener {
-            if (isPlaying) {
-                binding.btnPlayPause.text = "Play"
-                isPlaying = false
-                native_onStopPlaying()
-            } else {
-                isPlaying = true
-                binding.btnPlayPause.text = "Pause"
-                native_onStartPlaying()
-            }
-        }
-
-        //Incrementa / decrementa a quantidade de bpms
-        binding.btnMoreOne.setOnClickListener {
-            bpm += 1
-            binding.tvBpm.text = bpm.toString()
-            native_SetBPM(bpm)
-        }
-        binding.btnMoreThen.setOnClickListener {
-            bpm += 10
-            binding.tvBpm.text = bpm.toString()
-            native_SetBPM(bpm)
-        }
-        binding.btnMinusOne.setOnClickListener {
-            bpm -= 1
-            binding.tvBpm.text = bpm.toString()
-            native_SetBPM(bpm)
-        }
-        binding.btnMinusThen.setOnClickListener {
-            bpm -= 10
-            binding.tvBpm.text = bpm.toString()
-            native_SetBPM(bpm)
-        }
-
-        // Incrementa / decrementa a quantidade de batidas
-
-        tones = mutableListOf(
-            Beat(BeatState.Accent),
-            Beat(BeatState.Normal),
-            Beat(BeatState.Normal),
-            Beat(BeatState.Normal)
-        )
-
-        binding.btnMoreOneBeat.setOnClickListener {
-            beats += 1
-            binding.beatCounter.text = beats.toString()
-
-            tones.add(Beat(BeatState.Normal))
-
-            native_SetBeats(tones.map { it }.toTypedArray())
-        }
-        binding.btnMinusOneBeat.setOnClickListener {
-            beats -= 1
-            binding.beatCounter.text = beats.toString()
-
-            tones.removeAt(tones.lastIndex)
-
-            native_SetBeats(tones.map { it }.toTypedArray())
-        }
-    }
-
-    private fun setTextHelloC() {
-        binding.tvHello.apply {
-            text = "${text} ${helloC()}"
-        }
-    }
-
-    private fun setDefaultStreamValues() {
-        val myAudioMgr = getSystemService(AUDIO_SERVICE) as AudioManager
-        val sampleRateStr = myAudioMgr.getProperty(AudioManager.PROPERTY_OUTPUT_SAMPLE_RATE)
-        val defaultSampleRate = sampleRateStr.toInt()
-        val framesPerBurstStr =
-            myAudioMgr.getProperty(AudioManager.PROPERTY_OUTPUT_FRAMES_PER_BUFFER)
-        val defaultFramesPerBurst = framesPerBurstStr.toInt()
-
-        native_setDefaultStreamValues(defaultSampleRate, defaultFramesPerBurst)
-    }
-
-    private external fun helloC(): String
-    private external fun native_onInit(assetManager: AssetManager)
-    private external fun native_onEnd()
-    private external fun native_SetBPM(bpm: Int)
-    private external fun native_SetBeats(beats: Array<Beat>)
-    private external fun native_onStartPlaying()
-    private external fun native_onStopPlaying()
-    private external fun native_setDefaultStreamValues(
-        defaultSampleRate: Int,
-        defaultFramesPerBurst: Int
-    )
-
-    companion object {
-        init {
-            System.loadLibrary("metronomeplus-lib")
         }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,130 +7,14 @@
     android:layout_height="match_parent"
     tools:context=".presenter.ui.MainActivity">
 
-    <TextView
-        android:id="@+id/tvHello"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="20dp"
-        android:text="Hello World!"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-
-    <LinearLayout
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container_view"
+        class="br.com.jonatas.metronomeplus.presenter.ui.fragment.MetronomeFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"
-        android:gravity="center"
-        android:orientation="vertical"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_margin="8dp"
-            android:orientation="horizontal">
-
-            <Button
-                android:id="@+id/btnMinusThen"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
-                android:layout_weight="20"
-                android:text="-10" />
-
-            <Button
-                android:id="@+id/btnMinusOne"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="20"
-                android:text="-1" />
-
-            <TextView
-                android:id="@+id/tvBpm"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="20"
-                android:text="120"
-                android:textAlignment="center"
-                android:textSize="20sp"
-                android:textStyle="bold" />
-
-            <Button
-                android:id="@+id/btnMoreOne"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginEnd="8dp"
-                android:layout_weight="20"
-                android:text="+1" />
-
-            <Button
-                android:id="@+id/btnMoreThen"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_weight="20"
-                android:text="+10" />
-
-        </LinearLayout>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center"
-            android:orientation="vertical">
-
-            <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_gravity="center"
-                android:layout_marginHorizontal="8dp"
-                android:gravity="center"
-                android:orientation="horizontal">
-
-                <View
-                    android:layout_width="0dp"
-                    android:layout_height="5dp"
-                    android:layout_weight="40" />
-
-                <TextView
-                    android:id="@+id/beatCounter"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="20"
-                    android:inputType="number"
-                    android:text="4"
-                    android:textAlignment="center"
-                    android:textSize="20sp"
-                    android:textStyle="bold" />
-
-                <Button
-                    android:id="@+id/btnMinusOneBeat"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_marginEnd="8dp"
-                    android:layout_weight="20"
-                    android:text="-1" />
-
-                <Button
-                    android:id="@+id/btnMoreOneBeat"
-                    android:layout_width="0dp"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="20"
-                    android:text="+1" />
-
-            </LinearLayout>
-
-            <Button
-                android:id="@+id/btnPlayPause"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="Play" />
-
-        </LinearLayout>
-
-    </LinearLayout>
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Description of the change

Add code to use the Metronomefragment with the viewModel instead of the main activity.
The main activity has an old layout and code, so the metronome won't work without the rest of this change.
To adjust for this problem, it is necessary to update the layout and code of the main activity to use the fragment container in order to inflate the MetronomeFragment which uses all the structure explained in PR#3 which is the one before this one.

## Review Instructions
1. Check that the main activity code has been changed.
2. Check that the main activity is using the fragment container to inflate the MetronomeFragment. 
3. Check that the MetronomeFragment is being used correctly.